### PR TITLE
[FEATURE] Support for user functions as custom header values

### DIFF
--- a/Classes/Cundd/Rest/Dispatcher.php
+++ b/Classes/Cundd/Rest/Dispatcher.php
@@ -142,15 +142,17 @@ class Dispatcher implements SingletonInterface, ApiConfigurationInterface, Dispa
             // Let Bullet PHP do the hard work
             $response = $this->app->run($request);
 
-			// Additional custom headers
-			$additionalResponseHeaders = $this->objectManager->getConfigurationProvider()->getSetting('responseHeaders', array());
-			if (is_array($additionalResponseHeaders) && count($additionalResponseHeaders)){
-				foreach ($additionalResponseHeaders as $responseHeaderType => $value) {
-					if (is_string($value)) {
-						$response->header($responseHeaderType, $value);
-					}
-				}
-			}
+            // Additional custom headers
+            $additionalResponseHeaders = $this->objectManager->getConfigurationProvider()->getSetting('responseHeaders', array());
+            if (is_array($additionalResponseHeaders) && count($additionalResponseHeaders)){
+                foreach ($additionalResponseHeaders as $responseHeaderType => $value) {
+                    if (is_string($value)) {
+                        $response->header($responseHeaderType, $value);
+                    } elseif (is_array($value) && array_key_exists('userFunc', $value)) {
+                        $response->header(rtrim($responseHeaderType, '.'), GeneralUtility::callUserFunction($value['userFunc'], $value, $this));
+                    }
+                }
+            }
 
             // Handle exceptions
             if ($response->content() instanceof \Exception) {


### PR DESCRIPTION
This adds support for user functions for setting the custom header
value.

Example Typoscript:
plugin.tx_rest.settings {
	responseHeaders {
		Access-Control-Allow-Origin = USER
		Access-Control-Allow-Origin.userFunc =
Vendor\ExtensionName\User\AccessControl->getAllowOrigin
		Access-Control-Allow-Methods = GET, POST
	}
}

PHP-File:
namespace Vendor\ExtensionName\User;
class AccessControl {
	public function getAllowOrigin() {
		return '*';
	}
}