### PR TITLE
Add global LanguageService

### DIFF
--- a/Classes/Bootstrap.php
+++ b/Classes/Bootstrap.php
@@ -6,6 +6,7 @@ use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Utility\EidUtility;
+use TYPO3\CMS\Lang\LanguageService;
 
 /**
  * Class to bootstrap TYPO3 frontend controller
@@ -21,6 +22,8 @@ class Bootstrap
     public function init(TypoScriptFrontendController $frontendController = null)
     {
         $this->initializeTimeTracker();
+        $this->initializeLanguageObject();
+
         $frontendController = $frontendController ?: $this->buildFrontendController($this->getPageUid());
 
         if ($this->getFrontendControllerIsInitialized()) {
@@ -32,6 +35,18 @@ class Bootstrap
         $this->configureFrontendController($frontendController);
 
         return $frontendController;
+    }
+
+    /**
+     * Initialize language object
+     */
+    public function initializeLanguageObject()
+    {
+        if (!isset($GLOBALS['LANG']) || !is_object($GLOBALS['LANG'])) {
+            /** @var $GLOBALS['LANG'] \TYPO3\CMS\Lang\LanguageService */
+            $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageService::class);
+            $GLOBALS['LANG']->init($GLOBALS['BE_USER']->uc['lang']);
+        }
     }
 
     /**

--- a/Classes/Bootstrap.php
+++ b/Classes/Bootstrap.php
@@ -45,7 +45,7 @@ class Bootstrap
         if (!isset($GLOBALS['LANG']) || !is_object($GLOBALS['LANG'])) {
             /** @var $GLOBALS['LANG'] \TYPO3\CMS\Lang\LanguageService */
             $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageService::class);
-            $GLOBALS['LANG']->init($GLOBALS['BE_USER']->uc['lang']);
+            $GLOBALS['LANG']->init($this->getRequestedLanguageCode());
         }
     }
 


### PR DESCRIPTION
In my extension I used the TYPO3\CMS\Extensionmanager\Utility\ConfigurationUtility::getCurrentConfiguration method. This throws a exception, because $GLOBALS['LANG'] is null. I would add it to Bootstrap.php.