### PR TITLE
No access control on OPTIONS method

### DIFF
--- a/Classes/Access/ConfigurationBasedAccessController.php
+++ b/Classes/Access/ConfigurationBasedAccessController.php
@@ -25,6 +25,11 @@ class ConfigurationBasedAccessController extends AbstractAccessController
     const ACCESS_METHOD_WRITE = 'write';
 
     /**
+     * Access identifier to specify which methods DO NOT require authorization
+     */
+    const ACCESS_NOT_REQUIRED = ['OPTIONS'];
+
+    /**
      * @var \Cundd\Rest\Configuration\TypoScriptConfigurationProvider
      */
     protected $configurationProvider;
@@ -49,7 +54,7 @@ class ConfigurationBasedAccessController extends AbstractAccessController
      */
     public function getAccess(RestRequestInterface $request)
     {
-        if (!$request->isRead() && !$request->isWrite()) {
+        if (!$this->requiresAuthorization($request)) {
             return AccessControllerInterface::ACCESS_ALLOW;
         }
 
@@ -158,5 +163,15 @@ class ConfigurationBasedAccessController extends AbstractAccessController
         }
 
         return false;
+    }
+
+    /**
+     * Returns if the given request requires authorization
+     *
+     * @param RestRequestInterface $request
+     * @return bool
+     */
+    protected function requiresAuthorization($request) {
+        return !in_array(strtoupper($request->getMethod()), self::ACCESS_NOT_REQUIRED);
     }
 }

--- a/Classes/Access/ConfigurationBasedAccessController.php
+++ b/Classes/Access/ConfigurationBasedAccessController.php
@@ -49,17 +49,16 @@ class ConfigurationBasedAccessController extends AbstractAccessController
      */
     public function getAccess(RestRequestInterface $request)
     {
-        // OPTIONS method is neither read or write
         if (!$request->isRead() && !$request->isWrite()) {
             return AccessControllerInterface::ACCESS_ALLOW;
         }
 
         $configurationKey = self::ACCESS_METHOD_READ;
-        $configuration = $this->getConfigurationForResourceType(new ResourceType($request->getResourceType()));
         if ($request->isWrite()) {
             $configurationKey = self::ACCESS_METHOD_WRITE;
         }
 
+        $configuration = $this->getConfigurationForResourceType(new ResourceType($request->getResourceType()));
         // Throw an exception if the configuration is not complete
         if (!isset($configuration[$configurationKey])) {
             throw new InvalidConfigurationException($configurationKey . ' configuration not set', 1376826223);
@@ -152,18 +151,8 @@ class ConfigurationBasedAccessController extends AbstractAccessController
      */
     public function requestNeedsAuthentication(RestRequestInterface $request)
     {
-        $configurationKey = self::ACCESS_METHOD_READ;
-        $configuration = $this->getConfigurationForResourceType(new ResourceType($request->getResourceType()));
-        if ($request->isWrite()) {
-            $configurationKey = self::ACCESS_METHOD_WRITE;
-        }
+        $access = $this->getAccess($request);
 
-        // Throw an exception if the configuration is not complete
-        if (!isset($configuration[$configurationKey])) {
-            throw new InvalidConfigurationException($configurationKey . ' configuration not set', 1376826223);
-        }
-
-        $access = $configuration[$configurationKey];
         if ($access === AccessControllerInterface::ACCESS_REQUIRE_LOGIN) {
             return true;
         }

--- a/Classes/Access/ConfigurationBasedAccessController.php
+++ b/Classes/Access/ConfigurationBasedAccessController.php
@@ -56,7 +56,7 @@ class ConfigurationBasedAccessController extends AbstractAccessController
 
         $configurationKey = self::ACCESS_METHOD_READ;
         $configuration = $this->getConfigurationForResourceType(new ResourceType($request->getResourceType()));
-        if ($this->isWrite($request)) {
+        if ($request->isWrite()) {
             $configurationKey = self::ACCESS_METHOD_WRITE;
         }
 
@@ -144,17 +144,6 @@ class ConfigurationBasedAccessController extends AbstractAccessController
     }
 
     /**
-     * Returns if the request wants to write data
-     *
-     * @param RestRequestInterface $request
-     * @return bool
-     */
-    protected function isWrite(RestRequestInterface $request)
-    {
-        return $request->isWrite();
-    }
-
-    /**
      * Returns if the given request needs authentication
      *
      * @param RestRequestInterface $request
@@ -165,7 +154,7 @@ class ConfigurationBasedAccessController extends AbstractAccessController
     {
         $configurationKey = self::ACCESS_METHOD_READ;
         $configuration = $this->getConfigurationForResourceType(new ResourceType($request->getResourceType()));
-        if ($this->isWrite($request)) {
+        if ($request->isWrite()) {
             $configurationKey = self::ACCESS_METHOD_WRITE;
         }
 

--- a/Classes/Access/ConfigurationBasedAccessController.php
+++ b/Classes/Access/ConfigurationBasedAccessController.php
@@ -49,6 +49,11 @@ class ConfigurationBasedAccessController extends AbstractAccessController
      */
     public function getAccess(RestRequestInterface $request)
     {
+        // OPTIONS method is neither read or write
+        if (!$request->isRead() && !$request->isWrite()) {
+            return AccessControllerInterface::ACCESS_ALLOW;
+        }
+
         $configurationKey = self::ACCESS_METHOD_READ;
         $configuration = $this->getConfigurationForResourceType(new ResourceType($request->getResourceType()));
         if ($this->isWrite($request)) {

--- a/Classes/Request.php
+++ b/Classes/Request.php
@@ -149,7 +149,7 @@ class Request implements ServerRequestInterface, RestRequestInterface
      */
     public function isWrite()
     {
-        return !$this->isRead();
+        return !$this->isRead() && $this->getMethod() != 'OPTIONS';
     }
 
     /**


### PR DESCRIPTION
The OPTIONS method is neither a read nor write
operation. When used for preflight CORS header
discovery no auth can be sent.

This solution changed the isWrite method to
assert that an OPTIONS request is not a write
request. Further the ConfigurationBasedAccessController
is changed to allow requests are neither read
nor write.