### PR TITLE
[BUGFIX] Allow autodetected languages with the id 0

### DIFF
--- a/Classes/Bootstrap/LanguageBootstrap.php
+++ b/Classes/Bootstrap/LanguageBootstrap.php
@@ -95,7 +95,7 @@ class LanguageBootstrap
         $site = $routeResult->getSite();
 
         // If a language is requested explicitly look if it is available in the Site
-        if ($requestedLanguageUid) {
+        if (isset($requestedLanguageUid)) {
             $language = $site->getLanguageById($requestedLanguageUid);
         } else {
             $language = $routeResult->getLanguage();

--- a/Classes/Bootstrap/LanguageBootstrap.php
+++ b/Classes/Bootstrap/LanguageBootstrap.php
@@ -77,7 +77,7 @@ class LanguageBootstrap
 
         // TYPO3 v8
         if (!class_exists(SiteMatcher::class)) {
-            if ($requestedLanguageUid) {
+            if ($requestedLanguageUid !== null) {
                 return new LanguageInformation(
                     $requestedLanguageUid,
                     $this->getLanguageCodeForId($frontendController, $requestedLanguageUid)
@@ -95,7 +95,7 @@ class LanguageBootstrap
         $site = $routeResult->getSite();
 
         // If a language is requested explicitly look if it is available in the Site
-        if (isset($requestedLanguageUid)) {
+        if ($requestedLanguageUid !== null) {
             $language = $site->getLanguageById($requestedLanguageUid);
         } else {
             $language = $routeResult->getLanguage();
@@ -111,7 +111,7 @@ class LanguageBootstrap
         // Set language if defined
         if ($language && $language->getLanguageId() !== null) {
             return LanguageInformation::fromSiteLanguage($language);
-        } elseif ($requestedLanguageUid) {
+        } elseif ($requestedLanguageUid !== null) {
             return new LanguageInformation(
                 $requestedLanguageUid,
                 $this->getLanguageCodeForId($frontendController, $requestedLanguageUid)


### PR DESCRIPTION
Languages can have the UID 0 (in fact, the language with the id 0  is the default language), but this if-statement prevents the use of the default language even if it matches the Accept-Language-header or is set explicitly with ?L=0.
By checking with `isset` instead, we exclude only the cases where `$requestedLanguageUid` really is `null`