### PR TITLE
Breaking: #78384 - Static file inclusion has moved from ext_tables.php

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,34 @@
+<?php
+defined('TYPO3') or die();
+
+call_user_func(function()
+{
+   $extensionKey = 'rest';
+
+    if (version_compare(TYPO3_version, '10.4.0') >= 0) {
+        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+            $extensionKey,
+            'Configuration/TypoScript/Page/TYPO3-10',
+            'Virtual Object - Page'
+        );
+    } elseif (version_compare(TYPO3_version, '9.5.0') >= 0) {
+        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+            $extensionKey,
+            'Configuration/TypoScript/Page/TYPO3-9',
+            'Virtual Object - Page'
+        );
+    } else {
+        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+            $extensionKey,
+            'Configuration/TypoScript/Page/TYPO3-8',
+            'Virtual Object - Page'
+        );
+    }
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+        $extensionKey,
+        'Configuration/TypoScript/Content',
+        'Virtual Object - Content'
+    );
+
+});

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -5,37 +5,10 @@ if (!defined('TYPO3_MODE')) {
 
 call_user_func(
     function () {
-        if (version_compare(TYPO3_version, '10.4.0') >= 0) {
-            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-                'rest',
-                'Configuration/TypoScript/Page/TYPO3-10',
-                'Virtual Object - Page'
-            );
-        } elseif (version_compare(TYPO3_version, '9.5.0') >= 0) {
-            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-                'rest',
-                'Configuration/TypoScript/Page/TYPO3-9',
-                'Virtual Object - Page'
-            );
-        } else {
-            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-                'rest',
-                'Configuration/TypoScript/Page/TYPO3-8',
-                'Virtual Object - Page'
-            );
-        }
-
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-            'rest',
-            'Configuration/TypoScript/Content',
-            'Virtual Object - Content'
-        );
-
-
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['reports']['rest']['handler'] = [
             'title'       => 'LLL:EXT:rest/Resources/Private/Language/locallang_db.xlf:reports.handler.title',
             'description' => 'LLL:EXT:rest/Resources/Private/Language/locallang_db.xlf:reports.handler.description',
-//            'icon' => 'EXT:rest/Resources/Public/Icons/tx_additionalreports_' . $report[1] . '.png',
+            // 'icon' => 'EXT:rest/Resources/Public/Icons/tx_additionalreports_' . $report[1] . '.png',
             'report'      => \Cundd\Rest\Documentation\HandlerReport::class,
         ];
     }


### PR DESCRIPTION
… to TCA/Overrides/sys_template.php. Extension Compatibility Check will not pass and causing errors.

As of:

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/8.5/Breaking-78384-FrontendIgnoresTCAInExtTables.html?highlight=addstatic

and

https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/ExtensionArchitecture/FileStructure/ExtTables.html?highlight=extensionmanagementutility#should-not-be-used-for